### PR TITLE
added ability to add a javascript path

### DIFF
--- a/openjscad.js
+++ b/openjscad.js
@@ -306,12 +306,17 @@ OpenJsCad.javaScriptToSolidSync = function(script, mainParameters, debugging) {
 };
 
 // callback: should be function(error, csg)
-OpenJsCad.javaScriptToSolidASync = function(script, mainParameters, callback) {
+OpenJsCad.javaScriptToSolidASync = function(script, mainParameters, options, callback) {
   var baselibraries = [
     "csg.js",
     "openjscad.js"
   ];
-  var baseurl = document.location + "";
+
+  if (options['javascriptPath'] == null) {
+    var baseurl = document.location + "";
+  } else {
+    var baseurl = document.location.origin + '/' + options['javascriptPath'];
+  }
   var workerscript = "";
   workerscript += script;
   workerscript += "\n\n\n\n//// The following code is added by OpenJsCad:\n";
@@ -466,6 +471,7 @@ OpenJsCad.Processor = function(containerdiv, onchange) {
   this.script = null;
   this.hasError = false;
   this.debugging = false;
+  this.javascriptPath = null;
   this.createElements();
 };
 
@@ -577,6 +583,10 @@ OpenJsCad.Processor.prototype = {
     this.statusdiv.style.display = this.hasError? "none":"block";    
   },
   
+  setJavascriptPath: function(path) {
+    this.javascriptPath = path;
+  },
+
   setError: function(txt) {
     this.hasError = (txt != "");
     this.errorpre.innerText = txt;
@@ -680,7 +690,7 @@ OpenJsCad.Processor.prototype = {
     {
       try
       {
-        this.worker = OpenJsCad.javaScriptToSolidASync(this.script, paramValues, function(err, csg) {
+        this.worker = OpenJsCad.javaScriptToSolidASync(this.script, paramValues, { javascriptPath: this.javascriptPath }, function(err, csg) {
           that.processing = false;
           that.worker = null;
           if(err)

--- a/openjscad.js
+++ b/openjscad.js
@@ -315,7 +315,7 @@ OpenJsCad.javaScriptToSolidASync = function(script, mainParameters, options, cal
   if (options['javascriptPath'] == null) {
     var baseurl = document.location + "";
   } else {
-    var baseurl = document.location.origin + '/' + options['javascriptPath'];
+    var baseurl = 'http://' + document.location.host + '/' + options['javascriptPath'];
   }
   var workerscript = "";
   workerscript += script;


### PR DESCRIPTION
The js files aren't always going to be in the same directory as the jscad files, so this gives the option of installing it on different pages.

I made the javascriptPath option on the Processor object, since OpenJsCad itself seems to have collections of functions, but no state. Therefore, I had to pass in the javascript path as part of options into javaScriptToSolidASync().
