### PR TITLE
fix user parametrized polyhedrons

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -2122,7 +2122,10 @@ CSG.polyhedron = function(options) {
 	});
 
 	// TODO: facecenters as connectors? probably overkill. Maybe centroid
-	return CSG.fromPolygons(polygons);
+	// the re-tesselation here happens because it's so easy for a user to
+	// create parametrized polyhedrons that end up with 1-2 dimensional polygons.
+	// These will create infinite loops at CSG.Tree()
+	return CSG.fromPolygons(polygons).reTesselated();
 };
 
 CSG.IsFloat = function(n) {


### PR DESCRIPTION
if a user creates parametrized polyhedrons, it's easy to create
1 or 2-dimensional polygons by mistake. This messes up the CSG.Tree() call
unless the object is re-tesselated before the call.
