### PR TITLE
Added AMF export

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -1,3 +1,21 @@
+/*
+## License
+
+Copyright (c) 2014 bebbi (elghatta@gmail.com)
+Copyright (c) 2013 Eduard Bespalov (edwbes@gmail.com)
+Copyright (c) 2012 Joost Nieuwenhuijse (joost@newhouse.nl)
+Copyright (c) 2011 Evan Wallace (http://evanw.github.com/csg.js/)
+Copyright (c) 2012 Alexandre Girard (https://github.com/alx)
+
+All code released under MIT license
+
+*/
+
+if(typeof module !== 'undefined') {    // used via nodejs
+    CSG = require(lib+'csg.js').CSG;
+    CAG = require(lib+'csg.js').CAG;
+}
+
 ////////////////////////////////////////////
 // X3D Export
 ////////////////////////////////////////////
@@ -255,5 +273,67 @@ CAG.PathsToDxf = function(paths) {
 CAG.prototype.toDxf = function() {
     var paths = this.getOutlinePaths();
     return CAG.PathsToDxf(paths);
+};
+
+////////////////////////////////////////////
+// AMF Export
+////////////////////////////////////////////
+
+CSG.prototype.toAMFString = function(m) {
+    var result = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<amf"+(m&&m.unit?" unit=\"+m.unit\"":"")+">\n";
+    for(var k in m) {
+        result += "<metadata type=\""+k+"\">"+m[k]+"</metadata>\n";
+    }
+    result += "<object id=\"0\">\n<mesh>\n<vertices>\n";
+
+    this.polygons.map(function(p) {                  // first we dump all vertices of all polygons
+        for(var i=0; i<p.vertices.length; i++) {
+            result += p.vertices[i].toAMFString();
+        }
+    });
+    result += "</vertices>\n";
+
+    var n = 0;
+    this.polygons.map(function(p) {                  // then we dump all polygons
+        result += "<volume>\n";
+        if(p.vertices.length<3)
+            return;
+        var r = 1, g = 0.4, b = 1, a = 1, colorSet = false;
+        if(p.shared && p.shared.color) {
+            r = p.shared.color[0];
+            g = p.shared.color[1];
+            b = p.shared.color[2];
+            a = p.shared.color[3];
+            colorSet = true;
+        } else if(p.color) {
+            r = p.color[0];
+            g = p.color[1];
+            b = p.color[2];
+            if(p.color.length()>3) a = p.color[3];
+                colorSet = true;
+        }
+        result += "<color><r>"+r+"</r><g>"+g+"</g><b>"+b+"</b>"+(a!==undefined?"<a>"+a+"</a>":"")+"</color>";
+
+        for(var i=0; i<p.vertices.length-2; i++) {      // making sure they are all triangles (triangular polygons)
+            result += "<triangle>";
+            result += "<v1>" + (n) + "</v1>";
+            result += "<v2>" + (n+i+1) + "</v2>";
+            result += "<v3>" + (n+i+2) + "</v3>";
+            result += "</triangle>\n";
+        }
+        n += p.vertices.length;
+        result += "</volume>\n";
+    });
+    result += "</mesh>\n</object>\n";
+    result += "</amf>\n";
+    return result;
+};
+
+CSG.Vector3D.prototype.toAMFString = function() {
+    return "<x>" + this._x + "</x><y>" + this._y + "</y><z>" + this._z + "</z>";
+};
+
+CSG.Vertex.prototype.toAMFString = function() {
+   return "<vertex><coordinates>" + this.pos.toAMFString() + "</coordinates></vertex>\n";
 };
 


### PR DESCRIPTION
These are the changes to support the exporting of AMF formatted strings.

I was able to test the exporting of STL (text) using a modified shell script, but not the binary formats. It seems that BLOB objects are not defined in non-browser environments. It would be good to have this support for testing with NODEJS.

There's a small header change to support NODEJS. Please review.

In addition, the copyright was added.