### PR TITLE
add csg.stretchAtPlane(normal, point, length) function, see docu

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,6 +349,13 @@ var cube = CSG.roundedCube({
   resolution: 8,        // optional
 });
 
+// roundedCube works with a vector radius too:
+var cube = CSG.roundedCube({
+  radius: [10, 5, 8],
+  roundradius: [3, 5, 0.01],
+  resolution: 24
+});
+
 // a polyhedron (point ordering for faces: when looking at the face from the outside inwards, the points must be clockwise):
 var polyhedron = CSG.polyhedron({
    points:[ [10,10,0],[10,-10,0],[-10,-10,0],[-10,10,0], // the four points at base
@@ -467,6 +474,17 @@ var cube1 = CSG.cube({radius: 1.0});
 var cube2 = CSG.cube({radius: 1.0}).translate([-0.3, -0.3, -0.3]);
 var csg = cube1.subtract(cube2);
 var rounded = csg.expand(0.2, 8); 
+</pre>
+
+<h2>StretchAtPlane</h2>
+This cuts the object at the plane, and stretches the cross-section there by length amount.
+
+<pre>
+var stretched_csg = csg.stretchAtPlane(normal, point, length);
+In the gear example, function main, try replacing
+return gear;
+with
+return gear.stretchAtPlane([0, 0.05, 1], [0, 0, 0], 30);
 </pre>
 
 <h2>Using Properties</h2>

--- a/src/csg.js
+++ b/src/csg.js
@@ -1518,8 +1518,8 @@ for solid CAD anyway.
                 break;
             }
             if (!sidemapisempty) {
-                throw new Error("!sidemapisempty");
-            // OpenJsCad.log("!sidemapisempty");
+                // throw new Error("!sidemapisempty");
+            OpenJsCad.log("!sidemapisempty");
             }
             return csg;
         },
@@ -1976,6 +1976,7 @@ for solid CAD anyway.
     //       resolution: 8,
     //     });
     CSG.roundedCube = function(options) {
+        var EPS = 1e-5;
         var minRR = 1e-2; //minroundradius 1e-3 gives rounding errors already
         var center, cuberadius;
         options = options || {};
@@ -2004,10 +2005,10 @@ for solid CAD anyway.
         }
         var res = CSG.sphere({radius:1, resolution:resolution});
         res = res.scale(roundradius);
-        cuberadius.x && (res = res.stretchAtPlane([1, 0, 0], [0, 0, 0], cuberadius.x));
-        cuberadius.y && (res = res.stretchAtPlane([0, 1, 0], [0, 0, 0], cuberadius.y));
-        cuberadius.z && (res = res.stretchAtPlane([0, 0, 1], [0, 0, 0], cuberadius.z));
-        res = res.translate([-cuberadius.x/2, -cuberadius.y/2, -cuberadius.z/2]);
+        innerradius.x > EPS && (res = res.stretchAtPlane([1, 0, 0], [0, 0, 0], innerradius.x));
+        innerradius.y > EPS && (res = res.stretchAtPlane([0, 1, 0], [0, 0, 0], innerradius.y));
+        innerradius.z > EPS && (res = res.stretchAtPlane([0, 0, 1], [0, 0, 0], innerradius.z));
+        res = res.translate([-innerradius.x/2, -innerradius.y/2, -innerradius.z/2]);
         res = res.reTesselated();
         res.properties.roundedCube = new CSG.Properties();
         res.properties.roundedCube.center = new CSG.Vertex(center);

--- a/src/csg.js
+++ b/src/csg.js
@@ -620,9 +620,8 @@ for solid CAD anyway.
         stretchAtPlane: function(normal, point, length) {
             var plane = CSG.Plane.fromNormalAndPoint(normal, point);
             var onb = new CSG.OrthoNormalBasis(plane);
-            var m = onb.getInverseProjectionMatrix();
             var crosssect = this.sectionCut(onb);
-            var midpiece = crosssect.extrudeInOrthonormalBasis(onb, length);//.setColor(0, 1, 0, 0.1);
+            var midpiece = crosssect.extrudeInOrthonormalBasis(onb, length);
             var piece1 = this.cutByPlane(plane);
             var piece2 = this.cutByPlane(plane.flipped());
             var result = piece1.union([midpiece, piece2.translate(plane.normal.times(length))]);


### PR DESCRIPTION
improve CSG.roundedCube for size and performance at higher resolution, and allow vector radius, see docu
fix issues with sectionCut and some minor stuff. Work around some more nasty rounding errors without getting to root cause.
StretchAtPlane may fail because of them, e.g. if minRR = 1e-3 in roundedCube