### PR TITLE
Joost setcolor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1119,15 +1119,16 @@ function main() {
 </pre>
 
 <h2>Miscellaneous</h2>
-Solids can be given a color using the setColor(r, g, b) function. Beware: this returns a new solid,
+Solids can be given a color using the setColor() function. setColor() expects an array with 3 or 4
+elements [r, g, b, [alpha]]. Beware: this returns a new solid,
 the original solid is not modified! Faces of the solid will keep their original color when doing
-CSG operations (union() etc). Colors values range between 0.0 and 1.0 (not 255).  
+CSG operations (union() etc). Color values range between 0.0 and 1.0 (not 255).  
 <pre>
 var cube1 = CSG.cube({radius: 10});
-cube1 = cube1.setColor(0.5, 0, 0);
+cube1 = cube1.setColor([0.5, 0, 0]);
 
 var cube2 = CSG.cube({radius: 10});
-cube2 = cube2.setColor(0, 0.5, 0);
+cube2 = cube2.setColor([0, 0.5, 0]);
 cube2 = cube2.translate([5,1,4]);
 
 var result = cube1.subtract(cube2);

--- a/src/csg.js
+++ b/src/csg.js
@@ -823,8 +823,8 @@ for solid CAD anyway.
             return result;
         },
 
-        setColor: function(red, green, blue, alpha) {
-            var newshared = new CSG.Polygon.Shared([red, green, blue, isNaN(parseFloat(alpha)) ? 1 : alpha ]);
+        setColor: function(args) {
+            var newshared = CSG.Polygon.Shared.fromColor.apply(this, arguments);
             return this.setShared(newshared);
         },
 
@@ -2470,8 +2470,9 @@ for solid CAD anyway.
             }
         },
 
-        setColor: function(color) {
-            this.shared = new CSG.Polygon.Shared(color);
+        setColor: function(args) {
+            var newshared = CSG.Polygon.Shared.fromColor.apply(this, arguments);
+            this.shared = newshared;
             return this;
         },
 
@@ -2891,12 +2892,41 @@ for solid CAD anyway.
 
     // # class CSG.Polygon.Shared
     // Holds the shared properties for each polygon (currently only color)
+    // Constructor expects a 4 element array [r,g,b,a], values from 0 to 1, or null
     CSG.Polygon.Shared = function(color) {
+        if(color !== null)
+        {
+            if (color.length != 4) {
+                throw new Error("Expecting 4 element array");
+            }
+        }
         this.color = color;
     };
 
     CSG.Polygon.Shared.fromObject = function(obj) {
         return new CSG.Polygon.Shared(obj.color);
+    };
+
+    // Create CSG.Polygon.Shared from a color, can be called as follows:
+    // var s = CSG.Polygon.Shared.fromColor(r,g,b [,a])
+    // var s = CSG.Polygon.Shared.fromColor([r,g,b [,a]])
+    CSG.Polygon.Shared.fromColor = function(args) {
+        var color;
+        if(arguments.length == 1) {
+            color = arguments[0].slice(); // make deep copy
+        }
+        else {
+            color = [];
+            for(var i=0; i < arguments.length; i++) {
+                color.push(arguments[i]);
+            }
+        }
+        if(color.length == 3) {
+            color.push(1);
+        } else if(color.length != 4) {
+            throw new Error("setColor expects either an array with 3 or 4 elements, or 3 or 4 parameters.");
+        }
+        return new CSG.Polygon.Shared(color);
     };
 
     CSG.Polygon.Shared.prototype = {


### PR DESCRIPTION
CSG.setColor() now expects array argument (but old syntax still supported)