### PR TITLE
Adjust docs and add symmetrical option for extrudeInOrthonormalBasis …

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,15 +671,15 @@ places the 2D area onto the 3D z=0 plane, and extrudes in the specified directio
 twist. This rotates the solid around the z axis (and not necessariy around the extrusion axis) during extrusion.  
 The total degrees of rotation is specified in the twistangle parameter, and twiststeps determine the number of steps
 between the bottom and top surface.</li>
-<li>To extrude in an arbitrary plane in 3D space, use extrudeInOrthonormalBasis(orthonormalbasis, depth). 
+<li>To extrude in an arbitrary plane in 3D space, use extrudeInOrthonormalBasis(orthonormalbasis, depth [, options]). 
 An orthonormal basis is a combination of a plane and a right-hand vector (read more about orthonormal bases below).
-depth is the extrusion thickness. This function extrudes symmetrically: half of the extrusion is in front of the plane, half is
-back from the plane.
+depth is the extrusion thickness. By default this extrudes asymmetrically, extending from the plane. Currently one option is supported:
+{symmetrical: true}, which causes the extrusion to be done symmetrically in two directions about the plane.
 </li>
-<li>To extrude in one of the standard cartesian planes, use extrudeInPlane(axis1, axis2, depth). axis1 and axis 2 are one
+<li>To extrude in one of the standard cartesian planes, use extrudeInPlane(axis1, axis2, depth [, options]). axis1 and axis 2 are one
    of ["X","Y","Z","-X","-Y","-Z"]. The 2D X coordinate is mapped to the 3D axis specified by axis1, and the 2D
 Y coordinate is mapped to the 3D axis specified by axis2. For example, extrudeInPlane("-Z","X", 10) extrudes such that the
-2D x coordinate maps to the 3D negated z coordinate, and the 2D y coordinate maps to the 3D x coordinate.</li>
+2D x coordinate maps to the 3D negated z coordinate, and the 2D y coordinate maps to the 3D x coordinate. For options see extrudeInOrthonormalBasis above.</li>
 </ul>
 A 3D solid can be converted back to a 2D CAG using sectionCut() and projectToOrthoNormalBasis().
 sectionCut() cuts the solid by a plane and returns the 2D intersection as a CAG object.

--- a/src/csg.js
+++ b/src/csg.js
@@ -5998,8 +5998,12 @@ for solid CAD anyway.
         // by rotating around the plane's origin. An additional right-hand vector should be specified as well,
         // and this is exactly a CSG.OrthoNormalBasis.
         // orthonormalbasis: characterizes the plane in which to extrude
-        // depth: thickness of the extruded shape. Extrusion is done symmetrically above and below the plane.
-        extrudeInOrthonormalBasis: function(orthonormalbasis, depth) {
+        // depth: thickness of the extruded shape. Extrusion is done from the plane towards above (unless 
+        // symmetrical option is set, see below)
+        //
+        // options:
+        //   {symmetrical: true}  // extrude symmetrically in two directions about the plane
+        extrudeInOrthonormalBasis: function(orthonormalbasis, depth, options) {
             // first extrude in the regular Z plane:
             if (!(orthonormalbasis instanceof CSG.OrthoNormalBasis)) {
                 throw new Error("extrudeInPlane: the first parameter should be a CSG.OrthoNormalBasis");
@@ -6007,6 +6011,10 @@ for solid CAD anyway.
             var extruded = this.extrude({
                 offset: [0, 0, depth]
             });
+            if(CSG.parseOptionAsBool(options, "symmetrical", false))
+            {
+                extruded = extruded.translate([0,0,-depth/2]);
+            }
             var matrix = orthonormalbasis.getInverseProjectionMatrix();
             extruded = extruded.transform(matrix);
             return extruded;
@@ -6016,8 +6024,8 @@ for solid CAD anyway.
         // one of ["X","Y","Z","-X","-Y","-Z"]
         // The 2d x axis will map to the first given 3D axis, the 2d y axis will map to the second.
         // See CSG.OrthoNormalBasis.GetCartesian for details.
-        extrudeInPlane: function(axis1, axis2, depth) {
-            return this.extrudeInOrthonormalBasis(CSG.OrthoNormalBasis.GetCartesian(axis1, axis2), depth);
+        extrudeInPlane: function(axis1, axis2, depth, options) {
+            return this.extrudeInOrthonormalBasis(CSG.OrthoNormalBasis.GetCartesian(axis1, axis2), depth, options);
         },
 
         // extruded=cag.extrude({offset: [0,0,10], twistangle: 360, twiststeps: 100});


### PR DESCRIPTION
…and extrudeInPlane

See https://github.com/joostn/OpenJsCad/issues/69

By default extrudeInOrthonormalBasis and extrudeInPlane are extruding
symmetrically. Adding ,{symmetrical: true} will give the former behavior
of extruding in two directions.