### PR TITLE
Added JSON Conversions of CSG and CAG

### DIFF
--- a/src/formats.js
+++ b/src/formats.js
@@ -346,6 +346,83 @@ CSG.Vertex.prototype.toAMFString = function() {
    return "<vertex><coordinates>" + this.pos.toAMFString() + "</coordinates></vertex>\n";
 };
 
+////////////////////////////////////////////
+// JSON Conversions
+////////////////////////////////////////////
+
+CSG.prototype.toJSON = function() {
+    var str = '{ "type": "csg","polygons": [';
+    var comma = '';
+    this.polygons.map(
+      function(polygon) {
+        str += comma;
+        str += JSON.stringify(polygon);
+        comma = ',';
+      }
+    );
+    str += '],';
+    str += '"isCanonicalized": ' + JSON.stringify(this.isCanonicalized)+',';
+    str += '"isRetesselated": '+JSON.stringify(this.isRetesselated);
+    str += '}';
+    return new Blob([str], {
+        type: "application/json"
+    });
+};
+
+// convert the given (anonymous JSON) object into CSG
+// Note: Any issues during conversion will result in exceptions
+CSG.prototype.fromJSON = function(o) {
+// verify the object IS convertable
+  if (o.type == 'csg') {
+    Object.setPrototypeOf(o, CSG.prototype);
+    o.polygons.map( function(p) {
+        Object.setPrototypeOf(p, CSG.Polygon.prototype);
+        p.vertices.map(function(v) {
+            Object.setPrototypeOf(v, CSG.Vertex.prototype);
+            Object.setPrototypeOf(v.pos, CSG.Vector3D.prototype);
+        });
+        Object.setPrototypeOf(p.shared, CSG.Polygon.Shared.prototype);
+        Object.setPrototypeOf(p.plane, CSG.Plane.prototype);
+        Object.setPrototypeOf(p.plane.normal, CSG.Vector3D.prototype);
+    });
+    o.properties = new CSG.Properties();
+  }
+  return o;
+};
+
+CAG.prototype.toJSON = function() {
+    var str = '{ "type": "cag","sides": [';
+    var comma = '';
+    this.sides.map(
+      function(side) {
+        str += comma;
+        str += JSON.stringify(side);
+        comma = ',';
+      }
+    );
+    str += '] }';
+    return new Blob([str], {
+        type: "application/json"
+    });
+};
+
+// convert the given (anonymous JSON) object into CAG
+// Note: Any issues during conversion will result in exceptions
+CAG.prototype.fromJSON = function(o) {
+// verify the object IS convertable
+  if (o.type == 'cag') {
+    Object.setPrototypeOf(o, CAG.prototype);
+    o.sides.map( function(side) {
+        Object.setPrototypeOf(side, CAG.Side.prototype);
+        Object.setPrototypeOf(side.vertex0, CAG.Vertex.prototype);
+        Object.setPrototypeOf(side.vertex1, CAG.Vertex.prototype);
+        Object.setPrototypeOf(side.vertex0.pos, CSG.Vector2D.prototype);
+        Object.setPrototypeOf(side.vertex1.pos, CSG.Vector2D.prototype);
+        }
+    );
+  }
+  return o;
+};
 
 // re-export CSG and CAG with the extended prototypes
     module.CSG = CSG;

--- a/src/formats.js
+++ b/src/formats.js
@@ -11,14 +11,19 @@ All code released under MIT license
 
 */
 
+// import the required modules if necessary
+
 if(typeof module !== 'undefined') {    // used via nodejs
     CSG = require(lib+'csg.js').CSG;
     CAG = require(lib+'csg.js').CAG;
+    Blob = require(lib+'Blob.js').Blob;
 }
 
 ////////////////////////////////////////////
 // X3D Export
 ////////////////////////////////////////////
+
+(function(module) {
 
 CSG.prototype.toX3D = function() {
     // materialPolygonLists
@@ -204,7 +209,9 @@ CSG.prototype.toStlString = function() {
         result += p.toStlString();
     });
     result += "endsolid csg.js\n";
-    return result;
+    return new Blob([result], {
+        type: "application/sla"
+    });
 };
 
 CSG.Vector3D.prototype.toStlString = function() {
@@ -326,7 +333,9 @@ CSG.prototype.toAMFString = function(m) {
     });
     result += "</mesh>\n</object>\n";
     result += "</amf>\n";
-    return result;
+    return new Blob([result], {
+        type: "application/amf+xml"
+    });
 };
 
 CSG.Vector3D.prototype.toAMFString = function() {
@@ -336,4 +345,10 @@ CSG.Vector3D.prototype.toAMFString = function() {
 CSG.Vertex.prototype.toAMFString = function() {
    return "<vertex><coordinates>" + this.pos.toAMFString() + "</coordinates></vertex>\n";
 };
+
+
+// re-export CSG and CAG with the extended prototypes
+    module.CSG = CSG;
+    module.CAG = CAG;
+})(this);
 


### PR DESCRIPTION
I've provided the conversions to and from JSON for both CAG and CSG. These functions allow CAG / CAG objects to be instantiated via JSON objects as provided by AJAX or other frameworks.

The TO functions just traverse the CSG / CAG objects and convert the critical pieces to JSON.
The FROM functions force prototypes on anonymous objects, which is non-standard but very very fast.

I'll provided some performance numbers later this week, comparing Compact Binary, JSON, and STL conversions.

I also synchronized revisions in OpenJsCad and OpenJSCAD versions. It's critical that all TO functions return BLOBs.