### PR TITLE
Bug Fixes and Syncronization with OpenJSCAD.org

### DIFF
--- a/src/csg.js
+++ b/src/csg.js
@@ -5275,6 +5275,7 @@ for solid CAD anyway.
          http://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
          */
         appendArc: function(endpoint, options) {
+            var decimals = 100000;
             if (arguments.length < 2) {
                 options = {};
             }
@@ -5302,6 +5303,10 @@ for solid CAD anyway.
             var largearc = CSG.parseOptionAsBool(options, "large", false);
             var startpoint = this.points[this.points.length - 1];
             endpoint = new CSG.Vector2D(endpoint);
+            // round to precision in order to have determinate calculations
+            xradius = Math.round(xradius*decimals)/decimals;
+            yradius = Math.round(yradius*decimals)/decimals;
+            endpoint = new CSG.Vector2D(Math.round(endpoint.x*decimals)/decimals,Math.round(endpoint.y*decimals)/decimals);
 
             var sweep_flag = !clockwise;
             var newpoints = [];
@@ -5319,7 +5324,10 @@ for solid CAD anyway.
                 var sinphi = Math.sin(phi);
                 var minushalfdistance = startpoint.minus(endpoint).times(0.5);
                 // F.6.5.1:
-                var start_translated = new CSG.Vector2D(cosphi * minushalfdistance.x + sinphi * minushalfdistance.y, -sinphi * minushalfdistance.x + cosphi * minushalfdistance.y);
+                // round to precision in order to have determinate calculations
+                var x = Math.round((cosphi * minushalfdistance.x + sinphi * minushalfdistance.y)*decimals)/decimals;
+                var y = Math.round((-sinphi * minushalfdistance.x + cosphi * minushalfdistance.y)*decimals)/decimals;
+                var start_translated = new CSG.Vector2D(x,y);
                 // F.6.6.2:
                 var biglambda = start_translated.x * start_translated.x / (xradius * xradius) + start_translated.y * start_translated.y / (yradius * yradius);
                 if (biglambda > 1) {
@@ -5327,6 +5335,9 @@ for solid CAD anyway.
                     var sqrtbiglambda = Math.sqrt(biglambda);
                     xradius *= sqrtbiglambda;
                     yradius *= sqrtbiglambda;
+                    // round to precision in order to have determinate calculations
+                    xradius = Math.round(xradius*decimals)/decimals;
+                    yradius = Math.round(yradius*decimals)/decimals;
                 }
                 // F.6.5.2:
                 var multiplier1 = Math.sqrt((xradius * xradius * yradius * yradius - xradius * xradius * start_translated.y * start_translated.y - yradius * yradius * start_translated.x * start_translated.x) / (xradius * xradius * start_translated.y * start_translated.y + yradius * yradius * start_translated.x * start_translated.x));

--- a/src/formats.js
+++ b/src/formats.js
@@ -1,24 +1,35 @@
 /*
-## License
+## Formats.js
 
 Copyright (c) 2014 bebbi (elghatta@gmail.com)
 Copyright (c) 2013 Eduard Bespalov (edwbes@gmail.com)
+Copyright (c) 2013 Rene K. Mueller (spiritdude@gmail.com)
 Copyright (c) 2012 Joost Nieuwenhuijse (joost@newhouse.nl)
 Copyright (c) 2011 Evan Wallace (http://evanw.github.com/csg.js/)
 Copyright (c) 2012 Alexandre Girard (https://github.com/alx)
 
-All code released under MIT license
+Exporting CSG into various formats:
+   - STL (ASCII & Binary)
+   - DXF
+   - AMF 
+
+License: MIT license
 
 */
+
+// import the required modules if necessary
 
 if(typeof module !== 'undefined') {    // used via nodejs
     CSG = require(lib+'csg.js').CSG;
     CAG = require(lib+'csg.js').CAG;
+    Blob = require(lib+'Blob.js').Blob;
 }
 
 ////////////////////////////////////////////
 // X3D Export
 ////////////////////////////////////////////
+
+(function(module) {
 
 CSG.prototype.toX3D = function() {
     // materialPolygonLists
@@ -204,7 +215,9 @@ CSG.prototype.toStlString = function() {
         result += p.toStlString();
     });
     result += "endsolid csg.js\n";
-    return result;
+    return new Blob([result], {
+        type: "application/sla"
+    });
 };
 
 CSG.Vector3D.prototype.toStlString = function() {
@@ -326,7 +339,9 @@ CSG.prototype.toAMFString = function(m) {
     });
     result += "</mesh>\n</object>\n";
     result += "</amf>\n";
-    return result;
+    return new Blob([result], {
+        type: "application/amf+xml"
+    });
 };
 
 CSG.Vector3D.prototype.toAMFString = function() {
@@ -336,4 +351,9 @@ CSG.Vector3D.prototype.toAMFString = function() {
 CSG.Vertex.prototype.toAMFString = function() {
    return "<vertex><coordinates>" + this.pos.toAMFString() + "</coordinates></vertex>\n";
 };
+
+// re-export CSG and CAG with the extended prototypes
+    module.CSG = CSG;
+    module.CAG = CAG;
+})(this);
 

--- a/src/formats.js
+++ b/src/formats.js
@@ -80,7 +80,7 @@ CSG.prototype.toX3D = function() {
 
     // create output document
     var docType = document.implementation.createDocumentType("X3D",
-        'ISO//Web3D//DTD X3D 3.1//EN" "http://www.web3d.org/specifications/x3d-3.1.dtd', null);
+        "ISO//Web3D//DTD X3D 3.1//EN","http://www.web3d.org/specifications/x3d-3.1.dtd");
     var exportDoc = document.implementation.createDocument(null, "X3D", docType);
     exportDoc.insertBefore(
         exportDoc.createProcessingInstruction('xml', 'version="1.0" encoding="UTF-8"'),


### PR DESCRIPTION
These changes bring OpenJSCAD.org and OpenJsCad in synchronization again.

There are some changes in formats.js which may effect the HTML page of OpenJsCad. Please review.

In addition, there are two bug fixes.
- Corrected DocumentType when creating X3D documents (formats.js)
- Added rounding in CAG.appendArc()

I found that appendArc() was having issues with calculations of distances and deltas. This caused NaN numbers and incomplete processing.

Here's an example script.

`function main( p ) {
    var cx = 14.111109999999998;
    var cy = -21.166665;
    var rx = 8.466665999999998;
    var ry = 14.111109999999998;

    var e2 = new CSG.Path2D([[cx,cy + ry]]);
        e2 = e2.appendArc([cx,cy - ry], {
            xradius: rx,
            yradius: ry,
            xaxisrotation: 0,
            resolution: 72,
            clockwise: true,
            large: false,
        });
    e2 = e2.close();
    return e2.innerToCAG();
}'
