### PR TITLE
Update gears.jscad

### DIFF
--- a/examples/gears.jscad
+++ b/examples/gears.jscad
@@ -67,7 +67,7 @@ function involuteGear(numTeeth, circularPitch, pressureAngle, clearance, thickne
   for(var i = 0; i <= resolution; i++)
   {
     // first side of the tooth:
-    var angle = maxangle * i / resolution;
+    var angle = maxangle * Math.pow(i/resolution, 2/3);
     var tanlength = angle * baseRadius;
     var radvector = CSG.Vector2D.fromAngle(angle);    
     var tanvector = radvector.normal();


### PR DESCRIPTION
Existing code picks points on involute curve with uniform angle steps. This gives small steps on the curve close to the base circle, and larger steps away, with larger steps deviating more from the involute curve.

Deviation goes with angle*(angle step)^2. Taking the angle proportional to (i/resolution)^2/3 keeps deviation uniform, making the most out of the steps available.